### PR TITLE
docs: Restructure and Enhance Documentation for Different Audiences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,29 @@
-# Contributing to vector_recsys_lite
+# Contributing to vector-recsys-lite
 
-Thank you for your interest in contributing! 🎉
+Thanks for your interest! We welcome contributions that improve education or usability.
 
-## How to Contribute
+## Reporting Issues
 
-- Fork the repository and create your branch from `main`.
-- Make your changes with clear, descriptive commit messages.
-- Ensure your code is well-documented and type-annotated.
-- Add or update tests for any new features or bug fixes.
-- Run all tests and linting before submitting a pull request.
-- Open a pull request and describe your changes.
+1. Check existing issues
+2. Open new issue with template
+3. Include: description, steps to reproduce, environment
 
-## Code Style
+## Contributing Code
 
-- Use [Black](https://github.com/psf/black) for formatting.
-- Use [isort](https://pycqa.github.io/isort/) for import sorting.
-- Use [ruff](https://github.com/astral-sh/ruff) for linting.
-- Type annotations are required for all public functions.
-- Docstrings are required for all public functions and classes.
+1. Fork repo
+2. Create branch: `git checkout -b feat/my-feature`
+3. Develop with `make dev`
+4. Test: `make test`
+5. Lint: `make lint`
+6. Commit: `git commit -m 'feat: add my feature'`
+7. Push: `git push origin feat/my-feature`
+8. Open PR with clear title/description
 
-## Running Tests and Linting
+## Code Standards
+- Python 3.9+
+- Black formatting
+- Type hints
+- Tests for new features (>80% coverage)
+- Docstrings in Google style
 
-```bash
-make lint
-make test
-```
-
-Or, with Poetry:
-
-```bash
-poetry run pytest
-poetry run black --check src/ tests/
-poetry run isort --check src/ tests/
-poetry run ruff src/ tests/
-```
-
-## Pull Request Checklist
-
-- [ ] All tests pass
-- [ ] Linting passes
-- [ ] Code is documented and type-annotated
-- [ ] PR description is clear and complete
-
-Thank you for helping make this project better! 🚀
+See [developer_guide.md](docs/developer_guide.md) for more.

--- a/README.md
+++ b/README.md
@@ -8,225 +8,98 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-> **The lightweight recommender system for teaching and small-scale production**
+**Lightweight SVD recommender for teaching and small-scale production.**
 
-Built for educators and students in resource-constrained environments, vector-recsys-lite makes recommendation systems accessible to everyone. Whether you're teaching SVD math on a 10-year-old laptop in a university with unreliable internet, or deploying a small recommendation service for a local library, this library has you covered.
+Designed for educators in resource-constrained environments and developers building simple recommenders. Runs offline on old hardware, teaches concepts interactively, deploys easily.
 
-## 🎯 Who This Is For
+[Quick Start](#🚀-getting-started) | [Educator Guide](#🎓-for-educators--students) | [Deployment](#🚀-for-small-app-deployers) | [Developers](#🛠️-for-developers)
 
-- **Educators** teaching recommendation systems with limited lab resources
-- **Students** learning on old hardware or with poor internet connectivity
-- **Developers** building small-scale recommendation features (< 10k users/items)
-- **Researchers** needing a simple, hackable SVD implementation
+## 🌟 Why Choose This?
 
-## 🌍 Why We Built This
+- **Education-Focused**: Interactive teaching mode + notebooks
+- **Resource-Light**: <50MB install, runs on 2GB RAM
+- **Offline-Ready**: No internet needed after install
+- **Simple Production**: One-command API deployment
 
-In many parts of the world, especially in African universities and developing regions, students and educators face:
-- Old computers with limited RAM (2-4GB)
-- Unreliable or no internet connectivity
-- Need for practical, hands-on learning tools
-- Requirement for production-ready code that works at small scale
+See [Use Cases](#📚-use-cases).
 
-vector-recsys-lite solves these problems by being truly lightweight, offline-capable, and educationally focused while maintaining production quality.
-
-## ✨ Key Features
-
-- **🎓 Educational First** - Built-in teaching mode, step-by-step explanations, Jupyter examples
-- **💾 Truly Lightweight** - Core runs on 2GB RAM, minimal dependencies (NumPy + SciPy only)
-- **📡 Offline Capable** - Works without internet, includes offline install guide
-- **⚡ Fast on Old Hardware** - Optimized for older CPUs, optional Numba acceleration
-- **🔧 Simple Yet Extensible** - Clean API for learning, powerful enough for production
-- **📊 Multi-format I/O** - CSV, JSON, Parquet support for various data sources
-- **🚀 Quick Deployment** - One-command API generation for small-scale production
-
-Built for both rapid prototyping and production deployment, vector-recsys-lite delivers enterprise-grade recommendation capabilities without the complexity of heavyweight frameworks.
-
-## 🚀 Quick Start
+## 🚀 Getting Started
 
 ### Installation
 
 ```bash
-# From PyPI
 pip install vector_recsys_lite
-
-# From source
-git clone https://github.com/Lunexa-AI/lunexa-labs.git
-cd lunexa-labs/packages/vector_recsys_lite
-poetry install
 ```
 
-#### Offline Installation (for low-network environments)
-To install without internet:
-1. On a machine with internet: `pip download vector_recsys_lite --no-deps`
-2. Transfer the .whl file via USB.
-3. On target machine: `pip install vector_recsys_lite-<version>-py3-none-any.whl`
-This works on old laptops without network.
+Offline: See guide below.
 
-### Basic Usage
+### Quick Example
 
 ```python
 import numpy as np
 from vector_recsys_lite import svd_reconstruct, top_n
 
-# Create sample ratings matrix (users × items)
-ratings = np.array([
-    [5, 3, 0, 1],  # User 1: rated items 0,1,3
-    [0, 0, 4, 5],  # User 2: rated items 2,3
-    [1, 0, 0, 4],  # User 3: rated items 0,3
-], dtype=np.float32)
-
-# Generate recommendations
+ratings = np.array([[5, 3, 0, 1], [0, 0, 4, 5]], dtype=np.float32)
 reconstructed = svd_reconstruct(ratings, k=2)
-recommendations = top_n(reconstructed, ratings, n=3)
-
-print(f"Top-3 recommendations for {len(recommendations)} users:")
-for i, recs in enumerate(recommendations):
-    print(f"User {i}: {recs}")
+recommendations = top_n(reconstructed, ratings, n=2)
+print(recommendations)
 ```
 
-### CLI Usage
+CLI: `vector-recsys --help`
 
-```bash
-# Generate sample data
-vector-recsys sample ratings.csv --users 100 --items 50 --sparsity 0.8
+## 🎓 For Educators & Students
 
-# Generate recommendations
-vector-recsys predict ratings.csv --rank 20 --top-n 5 --metrics
+Teach recommendation systems without fancy hardware.
 
-# Run benchmarks
-vector-recsys benchmark ratings.csv --rank 50 --iterations 3
-```
+- **Interactive Mode**: `vector-recsys teach --concept svd` (prompts, examples)
+- **Notebooks**: `examples/svd_math_demo.ipynb` (math breakdowns, plots)
+- **Low-Resource Demos**: Generate data and run in <1s
 
-## 🎓 Educational Usage
+Full guide: [docs/educator_guide.md](docs/educator_guide.md)
 
-### Interactive Teaching Mode
-Perfect for classrooms without Jupyter:
+## 🚀 For Small App Deployers
 
-```bash
-# Teach SVD concepts interactively
-vector-recsys teach --concept svd
+Build production recommenders for <10k users/items.
 
-# Explain matrices and ratings
-vector-recsys teach --concept matrix
+- **Deploy API**: `vector-recsys deploy model.pkl`
+- **Offline Install**: Download wheel, install via USB
+- **Resource Efficient**: Sparse matrices for low memory
 
-# Show how recommendations work
-vector-recsys teach --concept recommendations
-```
+Examples: Library book recommender, local e-commerce.
 
-### Jupyter Notebooks
-For labs with Jupyter (optional):
+Full guide: [docs/deployment_guide.md](docs/deployment_guide.md)
 
-```bash
-# Check out our examples
-cd examples/
-jupyter notebook svd_math_demo.ipynb
-```
+## 🛠️ For Developers
 
-### Explaining Results
-Use `--explain` flag for step-by-step breakdowns:
+Extend or contribute easily.
 
-```bash
-# See the math behind predictions
-vector-recsys predict ratings.csv --explain
-```
+- **API**: Clean, typed functions (svd_reconstruct, RecommenderSystem)
+- **Contributing**: `make dev` setup, tests, linting
+- **Benchmarks**: `vector-recsys benchmark`
 
-## 📊 Features
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [API Reference](#🔧-api-reference).
 
-### 🎯 **Core Algorithms**
-- **Truncated SVD**: Matrix factorization for collaborative filtering
-- **Top-N Recommendations**: Exclude known items, rank by predicted ratings
-- **Sparse Matrix Support**: Memory-efficient for large datasets
-- **Numba Acceleration**: Optional JIT compilation for performance
+## 📚 Use Cases
 
-### 🔒 **Security & Reliability**
-- **Secure Serialization**: Uses `joblib` instead of `pickle` for model saving
-- **SQL Injection Protection**: Parameterized queries with identifier validation
-- **Robust Error Handling**: Comprehensive validation and error messages
-- **Type Safety**: Full type annotations with mypy compliance
+### Education
+- **University courses**: Teach recommendation systems without expensive infrastructure
+- **Self-learning**: Students can run everything on personal laptops
+- **Workshops**: Quick demos that work offline
+- **Research**: Simple baseline implementation for papers
 
-### 📁 **Multi-Format I/O**
-- **CSV**: Standard comma/tab-separated files
-- **JSON**: Structured data with metadata
-- **Parquet**: Columnar format for large datasets
-- **HDF5**: Hierarchical data format
-- **NPZ**: NumPy compressed format for sparse matrices
-- **SQLite**: Database storage with pivot table support
+### Small-Scale Production
+- **School library**: Recommend books to students (500 books, 200 students)
+- **Local business**: Product recommendations for small e-commerce
+- **Community app**: Match local services to residents
+- **Personal projects**: Add recommendations to your blog or app
 
-### 🎨 **Beautiful CLI**
-- **Rich Interface**: Progress bars, tables, and colored output
-- **Auto-detection**: Smart format detection from file extensions
-- **Comprehensive Help**: Detailed command documentation
-- **Benchmarking**: Performance testing with timing and metrics
+### Development
+- **Prototyping**: Test recommendation ideas quickly
+- **Learning**: Understand SVD by reading clean, documented code
+- **Benchmarking**: Compare against simple, fast baseline
+- **Integration**: Easy to embed in larger systems
 
-## 🛠️ CLI Commands
-
-### `vector-recsys sample`
-Generate synthetic rating matrices for testing.
-
-```bash
-# Basic usage
-vector-recsys sample ratings.csv
-
-# Custom parameters
-vector-recsys sample large_ratings.csv \
-  --users 1000 \
-  --items 200 \
-  --sparsity 0.9 \
-  --min-rating 1.0 \
-  --max-rating 5.0 \
-  --seed 42
-```
-
-### `vector-recsys predict`
-Generate top-N recommendations for users.
-
-```bash
-# Basic usage
-vector-recsys predict ratings.csv
-
-# With custom parameters
-vector-recsys predict ratings.csv \
-  --rank 50 \
-  --top-n 10 \
-  --output recommendations.csv \
-  --metrics \
-  --max-users 5
-```
-
-### `vector-recsys benchmark`
-Run performance benchmarks.
-
-```bash
-# Single benchmark
-vector-recsys benchmark ratings.csv
-
-# Multiple iterations
-vector-recsys benchmark ratings.csv \
-  --rank 100 \
-  --iterations 5
-```
-
-### `vector-recsys info`
-Show information about a ratings file.
-
-```bash
-vector-recsys info ratings.csv
-```
-
-### `vector-recsys convert`
-Convert between supported formats.
-
-```bash
-vector-recsys convert ratings.csv ratings.json
-vector-recsys convert ratings.csv ratings.parquet
-```
-
-### `vector-recsys evaluate`
-Evaluate prediction quality.
-
-```bash
-vector-recsys evaluate actual.csv predicted.csv
-```
+---
 
 ## 📈 Performance
 
@@ -392,276 +265,6 @@ def recommend(user_id: int, n: int = 5):
 - **Integration**: Easy to embed in larger systems
 
 ---
-
-## ❓ FAQ
-
-**Q: Why do I get 'package or version not found' on PyPI badges?**
-A: The package must be published to PyPI for these badges to work. See the PyPI section above.
-
-**Q: How do I enable Parquet or HDF5 support?**
-A: Install with the appropriate extras: `poetry install --with parquet,hdf5` or `pip install vector_recsys_lite[parquet,hdf5]`.
-
-**Q: Can I use this with very large datasets?**
-A: Yes! Use the sparse matrix support and optional Numba acceleration for best performance.
-
-**Q: How do I get reproducible results?**
-A: Set the `random_state` parameter in SVD functions or CLI commands.
-
----
-
-## ⚠️ Common Pitfalls
-
-- **Missing optional dependencies:** If you see errors about `pyarrow`, `h5py`, or `sqlalchemy`, install the relevant extras.
-- **Shape mismatches:** Ensure your ratings matrix is 2D (users × items).
-- **Sparse vs. dense confusion:** Use `as_dense` to convert sparse matrices for downstream processing.
-- **CLI not found:** Make sure you installed with `poetry install` or `pip install .` to get the `vector-recsys` command.
-
----
-
-## 💬 How to Get Help
-
-- **GitHub Issues:** [Open an issue](https://github.com/Lunexa-AI/vector-recsys-lite/issues) for bugs, questions, or feature requests.
-- **Discussions:** Use the GitHub Discussions tab for general Q&A.
-- **Email:** Contact the maintainer at stimire92@gmail.com for urgent matters.
-
----
-
-## 🛠️ CLI Commands
-
-### `vector-recsys sample`
-Generate synthetic rating matrices for testing.
-
-```bash
-# Basic usage
-vector-recsys sample ratings.csv
-
-# Custom parameters
-vector-recsys sample large_ratings.csv \
-  --users 1000 \
-  --items 200 \
-  --sparsity 0.9 \
-  --min-rating 1.0 \
-  --max-rating 5.0 \
-  --seed 42
-```
-
-### `vector-recsys predict`
-Generate top-N recommendations for users.
-
-```bash
-# Basic usage
-vector-recsys predict ratings.csv
-
-# With custom parameters
-vector-recsys predict ratings.csv \
-  --rank 50 \
-  --top-n 10 \
-  --output recommendations.csv \
-  --metrics \
-  --max-users 5
-```
-
-### `vector-recsys benchmark`
-Run performance benchmarks.
-
-```bash
-# Single benchmark
-vector-recsys benchmark ratings.csv
-
-# Multiple iterations
-vector-recsys benchmark ratings.csv \
-  --rank 100 \
-  --iterations 5
-```
-
-### `vector-recsys info`
-Show information about a ratings file.
-
-```bash
-vector-recsys info ratings.csv
-```
-
-### `vector-recsys convert`
-Convert between supported formats.
-
-```bash
-vector-recsys convert ratings.csv ratings.json
-vector-recsys convert ratings.csv ratings.parquet
-```
-
-### `vector-recsys evaluate`
-Evaluate prediction quality.
-
-```bash
-vector-recsys evaluate actual.csv predicted.csv
-```
-
-## 📈 Performance
-
-### Resource Usage
-
-Designed for resource-constrained environments:
-
-| Dataset Size | RAM Usage | Time (old laptop) | Time (modern PC) |
-|--------------|-----------|-------------------|------------------|
-| 100 × 50     | < 10 MB   | < 0.1s           | < 0.01s         |
-| 1K × 1K      | < 50 MB   | < 1s             | < 0.1s          |
-| 10K × 5K     | < 500 MB  | < 10s            | < 2s            |
-
-### Tested On
-- 10-year-old laptops (Core i3, 2GB RAM)
-- Raspberry Pi 4
-- Modern workstations
-- Cloud containers (minimal resources)
-
-### Memory Efficiency
-- **Sparse matrix support**: Handles 90% sparse data efficiently
-- **Chunked processing**: Works with limited RAM
-- **Minimal dependencies**: ~50MB total install size
-
-## 🔧 API Reference
-
-### Core Functions
-
-```python
-def svd_reconstruct(
-    mat: FloatMatrix,
-    *,
-    k: Optional[int] = None,
-    random_state: Optional[int] = None,
-    use_sparse: bool = True,
-) -> FloatMatrix:
-    """Truncated SVD reconstruction for collaborative filtering."""
-
-def top_n(
-    est: FloatMatrix,
-    known: FloatMatrix,
-    *,
-    n: int = 10
-) -> np.ndarray:
-    """Get top-N items for each user, excluding known items."""
-
-def compute_rmse(predictions: FloatMatrix, actual: FloatMatrix) -> float:
-    """Compute Root Mean Square Error between predictions and actual ratings."""
-
-def compute_mae(predictions: FloatMatrix, actual: FloatMatrix) -> float:
-    """Compute Mean Absolute Error between predictions and actual ratings."""
-```
-
-### I/O Functions
-
-```python
-def load_ratings(
-    path: Union[str, Path],
-    *,
-    format: Optional[str] = None,
-    sparse_format: bool = False,
-    **kwargs: Any,
-) -> FloatMatrix:
-    """Load matrix from file with format detection."""
-
-def save_ratings(
-    matrix: Union[FloatMatrix, sparse.csr_matrix],
-    path: Union[str, Path],
-    *,
-    format: Optional[str] = None,
-    show_progress: bool = True,
-    **kwargs: Any,
-) -> None:
-    """Save rating matrix with automatic format detection."""
-
-def create_sample_ratings(
-    n_users: int = 100,
-    n_items: int = 50,
-    sparsity: float = 0.8,
-    rating_range: tuple[float, float] = (1.0, 5.0),
-    random_state: Optional[int] = None,
-    sparse_format: bool = False,
-) -> Union[FloatMatrix, sparse.csr_matrix]:
-    """Create a sample rating matrix for testing."""
-```
-
-### RecommenderSystem Class
-
-```python
-class RecommenderSystem:
-    """Production-ready recommender system with model persistence."""
-
-    def fit(self, ratings: FloatMatrix, k: Optional[int] = None) -> "RecommenderSystem":
-        """Fit the model to training data."""
-
-    def predict(self, ratings: FloatMatrix) -> FloatMatrix:
-        """Generate predictions for the input matrix."""
-
-    def recommend(self, ratings: FloatMatrix, n: int = 10, exclude_rated: bool = True) -> np.ndarray:
-        """Generate top-N recommendations for each user."""
-
-    def save(self, path: str) -> None:
-        """Save model to file using secure joblib serialization."""
-
-    @classmethod
-    def load(cls, path: str) -> "RecommenderSystem":
-        """Load model from file."""
-```
-
-## 🐳 Docker Support
-
-```bash
-# Build Docker image
-docker build -t vector-recsys-lite .
-
-# Run CLI commands
-docker run vector-recsys-lite vector-recsys --help
-docker run vector-recsys-lite vector-recsys sample test.csv
-```
-
-## 🧪 Testing
-
-```bash
-# Run all tests
-poetry run pytest
-
-# Run with coverage
-poetry run pytest --cov=vector_recsys_lite
-
-# Run specific test categories
-poetry run pytest tests/test_algo.py
-poetry run pytest tests/test_io.py
-poetry run pytest tests/test_cli.py
-```
-
-## 📦 Dependencies
-
-### Required
-- `numpy>=1.21.0`: Numerical computing
-- `scipy>=1.7.0`: Sparse matrices and SVD
-- `joblib>=1.1.0`: Secure model serialization
-- `typer>=0.9.0`: CLI framework
-- `rich>=13.0.0`: Beautiful terminal output
-
-### Optional
-- `numba>=0.56.0`: JIT compilation for performance
-- `pandas>=1.3.0`: Data manipulation
-- `pyarrow>=7.0.0`: Parquet file support
-- `h5py>=3.7.0`: HDF5 file support
-- `sqlalchemy>=1.4.0`: SQLite database support
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/amazing-feature`
-3. Make your changes and run: `make ci`
-4. Commit your changes: `git commit -m 'Add amazing feature'`
-5. Push to the branch: `git push origin feature/amazing-feature`
-6. Open a Pull Request
-
-### Development Standards
-
-- **Type hints**: All functions have type annotations
-- **Docstrings**: All public functions have docstrings
-- **Tests**: New features include tests
-- **Linting**: Code passes all linting checks
-- **Coverage**: Maintain >80% test coverage
 
 ## 📄 License
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,18 +3,13 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-# Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
-
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+clean:
+	@rm -rf $(BUILDDIR)/*

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -1,0 +1,68 @@
+# Deployment Guide for Small Apps
+
+This guide shows how to deploy vector-recsys-lite in production for small-scale apps (<10k users/items). It's designed to be simple and resource-efficient.
+
+## Quick Setup
+
+1. **Install**: `pip install vector_recsys_lite`
+2. **Train Model**: Use CLI or API to create a model.pkl
+3. **Deploy**: Use the `deploy` command or integrate manually
+
+## One-Command Deployment
+
+```bash
+# Train a model (example)
+vector-recsys predict ratings.csv --output model.pkl  # Actually save via API
+
+# Generate API
+vector-recsys deploy model.pkl --port 8000
+
+# Run
+uvicorn deploy_app:app --port 8000
+```
+
+Access http://localhost:8000/recommend/0 for recs.
+
+## Integration Examples
+
+### FastAPI (Advanced)
+
+```python
+from fastapi import FastAPI
+from vector_recsys_lite import RecommenderSystem
+import numpy as np
+
+app = FastAPI()
+rec = RecommenderSystem.load('model.pkl')
+
+@app.get('/recommend/{user_id}')
+def recommend(user_id: int, n: int = 5):
+    # Get user ratings (from DB, etc.)
+    user_ratings = np.zeros((1, num_items))  # Example
+    preds = rec.predict(user_ratings)
+    recs = rec.recommend(preds, n=n)[0]
+    return {'recommendations': recs.tolist()}
+```
+
+### Script-Based Batch Processing
+
+For offline recommendations:
+
+```python
+import pandas as pd
+from vector_recsys_lite import RecommenderSystem
+
+rec = RecommenderSystem().fit(ratings_df.values)
+recs = rec.recommend(ratings_df.values)
+pd.DataFrame(recs).to_csv('recommendations.csv')
+```
+
+## Scaling for Small Datasets
+- **Memory Tips**: Use sparse matrices for >80% sparsity
+- **Performance**: Enable Numba: `pip install numba`
+- **Containerize**: Use our Dockerfile for cloud deployment
+- **Monitoring**: Add simple logging to API
+
+If datasets grow, consider migrating to larger libs like Implicit.
+
+Questions? Open an issue.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,51 @@
+# Developer Guide
+
+This guide is for developers extending or contributing to vector-recsys-lite. It assumes Python knowledge.
+
+## 🏗️ Project Structure
+
+- `src/vector_recsys_lite/`: Core code
+  - `algo.py`: SVD and recommendation logic
+  - `cli.py`: Command-line interface
+  - `explain.py`: Educational tools
+  - `io.py`: Data loading/saving
+- `tests/`: Unit tests
+- `examples/`: Jupyter notebooks
+- `docs/`: Guides like this one
+
+## 🔧 Extending the Library
+
+### Adding a New Algorithm
+1. Subclass `RecommenderSystem` in `algo.py`:
+
+```python
+class MyAlgorithm(RecommenderSystem):
+    def fit(self, ratings, **kwargs):
+        # Your implementation
+        pass
+```
+
+2. Add to CLI if needed.
+
+### Custom I/O Formats
+Extend `load_ratings` in `io.py` with new cases.
+
+Full examples in [API Reference](../README.md#🔧-api-reference).
+
+## 🤝 Contributing
+
+Follow [CONTRIBUTING.md](../CONTRIBUTING.md):
+1. Fork and branch: `git checkout -b feat/my-feature`
+2. Develop and test: `make test`
+3. Lint: `make lint`
+4. PR with clear description
+
+We welcome education-focused contributions!
+
+## ⚙️ Advanced Topics
+
+- **Performance Tuning**: Use Numba for JIT
+- **Testing**: `pytest --cov`
+- **Building Docs**: `cd docs; make html`
+
+See scikit-learn docs for inspiration on structure.

--- a/docs/educator_guide.md
+++ b/docs/educator_guide.md
@@ -1,0 +1,51 @@
+# Educator & Student Guide
+
+Welcome! This guide helps you use vector-recsys-lite for teaching recommendation systems in classrooms with limited resources.
+
+## Quick Setup
+
+1. **Install** (one-time, ~5 min):
+   - With internet: `pip install vector_recsys_lite`
+   - Offline: Download wheel on good connection, transfer via USB, `pip install <wheel>`
+
+2. **Test**: `vector-recsys --help` (should show commands)
+
+3. **For classrooms**: Share installed package via USB/external drive.
+
+## Teaching Workflows
+
+### 1. Basic Concepts (10 min demo)
+Use interactive mode:
+
+```bash
+vector-recsys teach --concept matrix  # Explains user-item matrix
+vector-recsys teach --concept svd     # SVD breakdown with example
+```
+
+Follow prompts to generate examples.
+
+### 2. Hands-on Lab (30 min)
+- Generate data: `vector-recsys sample class_data.csv --users 5 --items 4`
+- Predict: `vector-recsys predict class_data.csv --explain`
+- Discuss output: Shows matrix samples and math.
+
+### 3. Notebook Session (if Jupyter available)
+```bash
+cd examples/
+jupyter notebook svd_math_demo.ipynb
+```
+- Walk through sections, run cells - uses <1MB RAM.
+
+## Low-Resource Tips
+- **Old hardware**: Use sparse mode: `vector-recsys predict --use-sparse`
+- **No internet**: All features work offline after install
+- **Large classes**: Pre-install on lab computers
+- **Extensions**: Have students modify `RecommenderSystem` class
+
+## Sample Lesson Plan
+1. Intro (5 min): Explain matrix concept
+2. Demo (10 min): Run teach command
+3. Exercise (15 min): Students generate data and predict
+4. Discuss (10 min): Compare predictions to math
+
+Questions? Open an issue on GitHub.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,44 @@
+API Reference
+=============
+
+This page details the public API of vector-recsys-lite.
+
+Core Algorithms
+---------------
+
+.. automodule:: vector_recsys_lite.algo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+I/O Utilities
+-------------
+
+.. automodule:: vector_recsys_lite.io
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+CLI
+---
+
+.. automodule:: vector_recsys_lite.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Explanation Tools
+-----------------
+
+.. automodule:: vector_recsys_lite.explain
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+---------
+
+.. automodule:: vector_recsys_lite.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,22 @@ release = "0.1.4"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "myst_parser",  # For Markdown support
 ]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+}
+
+html_theme_options = {
+    "navigation_depth": 4,
+    "show_nav_level": 2,
+    "collapse_navigation": False,
+}
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,36 +1,28 @@
-.. vector_recsys_lite documentation master file, created by
-   sphinx-quickstart on Tue Jul 15 18:39:24 2025.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+vector-recsys-lite Documentation
+===========================
 
-Welcome to vector_recsys_lite's documentation!
-==============================================
+Welcome to the official documentation.
 
 .. toctree::
-   :maxdepth=2
-   :caption: Contents:
+   :maxdepth: 2
+   :caption: User Guides
 
+   educator_guide
+   deployment_guide
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developer Guides
+
+   developer_guide
    api
 
-Installation and Local Build Instructions
-========================================
+.. toctree::
+   :maxdepth: 1
+   :caption: Additional Resources
 
-To build the documentation locally:
-
-.. code-block:: bash
-
-   cd docs
-   make html
-
-The generated HTML will be in docs/build/html/index.html
-
-API Reference
-=============
-
-.. automodule:: vector_recsys_lite
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   contributing
+   changelog
 
 Indices and tables
 ==================


### PR DESCRIPTION
# Restructure and Enhance Documentation for Different Audiences

This PR overhauls the documentation to make it state-of-the-art, intuitive, and user-specific. Inspired by well-documented libraries like scikit-learn, I've separated concerns into targeted guides while keeping everything concise and easy to follow.

## Why This Change?
- **User-Centric**: Different audiences (educators/students, deployers, developers) get tailored docs
- **Intuitive Structure**: Clear sections, toctrees, and navigation like scikit-learn
- **Comprehensive Yet Concise**: Step-by-step with code blocks, no fluff
- **Sphinx Improvements**: Added Markdown support, intersphinx for external refs

## Key Changes
- **README.md**: Restructured as main hub with sections for each audience + quick links
- **New Guides**:
  - `docs/educator_guide.md`: Teaching workflows, lesson plans, low-resource tips
  - `docs/deployment_guide.md`: Simple prod setups, integration examples
  - `docs/developer_guide.md`: Extending API, contributing, advanced topics
- **Sphinx Docs**:
  - `docs/source/index.rst`: Clean toctree linking all guides + API
  - `docs/source/api.rst`: Automodule-based reference for all modules
  - `docs/source/conf.py`: Added myst_parser, viewcode, intersphinx
  - `docs/Makefile`: Simplified build commands
- **CONTRIBUTING.md**: Updated with clear steps, standards

## How It Improves Usability
- **Educators**: Quick teaching demos + offline tips
- **Deployers**: One-command deploys with examples
- **Developers**: Clear extension points + contrib guide
- Like scikit-learn: Separate user/developer docs, API ref

## Testing the Docs
1. Build locally: `cd docs; make html`
2. Open `docs/build/html/index.html`
3. Verify navigation, links, API rendering
4. Check Markdown guides render properly
